### PR TITLE
Fix SMTP TLS handshake failure when port is embedded in hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,14 @@ Use a fix name from the parentheses to disable it via `ckanext.core_fix.disable_
     Replaces the default Flask-Session Redis interface with msgspec.
     CKAN PR #8704 addresses the same issue with a different approach.
     https://github.com/ckan/ckan/pull/8704  
-    *Ongoing PR in CKAN core* 
+    *Already in master*
+
+10. Fix SMTP host:port parsing (`smtp_host_port_separation`)
+    Fixes SMTP TLS handshake failures when port is embedded in hostname.
+    Parses and separates host:port in smtp.server configuration to fix
+    TLS/SNI handshake errors with AWS SES and other SMTP providers.
+    https://github.com/ckan/ckan/pull/9186
+    *Ongoing PR in CKAN core*
 
 ## Config settings
 

--- a/ckanext/core_fix/config.py
+++ b/ckanext/core_fix/config.py
@@ -22,7 +22,8 @@ class Fixes(Enum):
     restyle_activity = auto()
     group_list_csrf = auto()
     dashboard_organization = auto()
-    redis_session = auto() 
+    redis_session = auto()
+    smtp_host_port_separation = auto()
 
 
 FIXES_WITH_TEMPLATES = [

--- a/ckanext/core_fix/plugin.py
+++ b/ckanext/core_fix/plugin.py
@@ -21,6 +21,7 @@ class CoreFixPlugin(p.SingletonPlugin):
         utils.check_disabled_fixes()
         utils.notify()
         utils.register_fix_templates(config_)
+        utils.apply_smtp_sni_fix()
 
         tk.add_template_directory(config_, "templates")
         tk.add_public_directory(config_, "public")

--- a/ckanext/core_fix/smtp_patch.py
+++ b/ckanext/core_fix/smtp_patch.py
@@ -1,0 +1,61 @@
+"""
+SMTP wrapper to handle host:port in server configuration.
+
+This patches smtplib.SMTP to automatically split host:port strings,
+fixing TLS handshake issues with AWS SES and other SMTP providers.
+"""
+from __future__ import annotations
+
+import smtplib
+import socket
+from urllib.parse import urlparse
+
+
+class SMTPHostPortWrapper(smtplib.SMTP):
+    """
+    Wrapper for smtplib.SMTP that handles host:port in the host parameter.
+
+    Some configurations may have the port embedded in the hostname string
+    (e.g., "smtp.example.com:587"). This causes TLS handshake failures
+    because the SNI (Server Name Indication) includes the port, which is invalid.
+
+    This wrapper automatically splits the host:port and passes them separately.
+    """
+
+    # socket._GLOBAL_DEFAULT_TIMEOUT is used as the default timeout value
+    def __init__(
+        self,
+        host="",
+        port=0,
+        local_hostname=None,
+        timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
+        source_address=None,
+    ):
+        """Initialize SMTP connection, automatically parsing host:port if needed."""
+        if host and ':' in host and port == 0:
+            host, port = self._parse_smtp_server(host)
+
+        super().__init__(host, port, local_hostname, timeout, source_address)
+
+    @staticmethod
+    def _parse_smtp_server(smtp_server: str) -> tuple[str, int]:
+        """Parse SMTP server that may include port.
+
+        Examples:
+            'smtp.example.com' -> ('smtp.example.com', 25)
+            'smtp.example.com:587' -> ('smtp.example.com', 587)
+            '[::1]:587' -> ('::1', 587)
+        """
+        default_port = 0
+
+        if '://' not in smtp_server:
+            smtp_server = 'smtp://' + smtp_server
+
+        parsed = urlparse(smtp_server)
+        host = parsed.hostname
+        port = parsed.port or default_port
+
+        if not host:
+            raise ValueError(f"Invalid SMTP server: {smtp_server}")
+
+        return host, port

--- a/ckanext/core_fix/utils.py
+++ b/ckanext/core_fix/utils.py
@@ -83,6 +83,7 @@ def apply_redis_session_fix(app, config) -> None:
 
 
 def apply_smtp_sni_fix():
+    """Apply SMTP host/port separation fix if enabled"""
     if is_fix_disabled(conf.Fixes.smtp_host_port_separation):
         return
 

--- a/ckanext/core_fix/utils.py
+++ b/ckanext/core_fix/utils.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import logging
+import smtplib
 
 import ckan.plugins.toolkit as tk
 
 import ckanext.core_fix.config as conf
+import ckanext.core_fix.smtp_patch as smtp_patch
 from ckanext.core_fix.exceptions import CoreFixException
 
 log = logging.getLogger(__name__)
@@ -66,7 +68,7 @@ def register_fix_templates(config_: tk.CKANConfig) -> None:
 def apply_redis_session_fix(app, config) -> None:
     """Apply Redis session interface fix if enabled and conditions are met"""
     # Check if Redis is used as session store and we're on CKAN 2.11+
-    if not (config.get("SESSION_TYPE", None) == "redis" and 
+    if not (config.get("SESSION_TYPE", None) == "redis" and
             tk.check_ckan_version(min_version="2.11")):
         return
 
@@ -78,3 +80,11 @@ def apply_redis_session_fix(app, config) -> None:
     from ckanext.core_fix.middleware import CoreFixRedisSessionInterface
     app.session_interface = CoreFixRedisSessionInterface(app)
     log.info("Applied Redis session fix")
+
+
+def apply_smtp_sni_fix():
+    if is_fix_disabled(conf.Fixes.smtp_host_port_separation):
+        return
+
+    smtplib.SMTP = smtp_patch.SMTPHostPortWrapper
+    log.info("Applied SMTP host/port separation fix")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ckanext-core-fix"
-version = "0.8.0"
+version = "0.9.0"
 description = ""
 authors = [
     {name = "DataShades", email = "datashades@linkdigital.com.au"},


### PR DESCRIPTION
When smtp.server is configured with embedded port (e.g., "smtp.example.com:587"), the TLS handshake fails with
SSLError: [SSL: SSLV3_ALERT_ILLEGAL_PARAMETER] because the SNI (Server Name Indication) includes the port in the hostname, which violates TLS specifications.
